### PR TITLE
Refactoring and fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ## Application details
 
-This is a Qt5 platform plugin to export application through RDP without modifying
+This is a Qt5/Qt6 platform plugin to export application through RDP without modifying
 the original code.
 
 ## Requirements

--- a/src/plugins/platforms/freerdp/qfreerdpbackingstore.cpp
+++ b/src/plugins/platforms/freerdp/qfreerdpbackingstore.cpp
@@ -38,6 +38,7 @@ QFreeRdpBackingStore::QFreeRdpBackingStore(QWindow *window, QFreeRdpPlatform *pl
 }
 
 QFreeRdpBackingStore::~QFreeRdpBackingStore() {
+	mPlatform->dropBackingStore(this);
 }
 
 QPaintDevice *QFreeRdpBackingStore::paintDevice() {
@@ -46,7 +47,6 @@ QPaintDevice *QFreeRdpBackingStore::paintDevice() {
 
 void QFreeRdpBackingStore::flush(QWindow *window, const QRegion &region, const QPoint &offset)
 {
-    Q_UNUSED(window);
     Q_UNUSED(offset);
 
     mPlatform->mWindowManager->pushDirtyArea(

--- a/src/plugins/platforms/freerdp/qfreerdpbackingstore.h
+++ b/src/plugins/platforms/freerdp/qfreerdpbackingstore.h
@@ -39,7 +39,7 @@ class QFreeRdpBackingStore : public QObject, public QPlatformBackingStore
 public:
     QFreeRdpBackingStore(QWindow *window, QFreeRdpPlatform *platform);
 
-    ~QFreeRdpBackingStore();
+    virtual ~QFreeRdpBackingStore();
 
     QPaintDevice *paintDevice() override;
 

--- a/src/plugins/platforms/freerdp/qfreerdpplatform.h
+++ b/src/plugins/platforms/freerdp/qfreerdpplatform.h
@@ -43,6 +43,7 @@ class QFreeRdpWindow;
 class QFreeRdpBackingStore;
 class QFreeRdpWindowManager;
 class QFreeRdpClipboard;
+class QFreeRdpCursor;
 
 enum DisplayMode {
 	UNKNOWN = 0,
@@ -92,9 +93,7 @@ struct QFreeRdpPlatformConfig {
 };
 
 
-/**
- * @brief
- */
+/** @brief FreeRDP based platform */
 class QFreeRdpPlatform : public QObject, public QPlatformIntegration {
 	friend class QFreeRdpScreen;
 	friend class QFreeRdpCursor;
@@ -110,6 +109,7 @@ public:
 	 */
 	QFreeRdpPlatform(const QString& system, const QStringList& paramList);
 
+	/** dtor */
 	virtual ~QFreeRdpPlatform();
 
     /** @overload QPlatformIntegration
@@ -136,17 +136,13 @@ public:
 	/** @return the main screen */
 	QFreeRdpScreen *getScreen() { return mScreen; }
 
-	/** @return */
+	/** @return clipboard */
 	QFreeRdpClipboard *rdpClipboard() const { return mClipboard; }
 
-	/**
-	 * @return listen address
-	 */
+	/** @return listen address */
 	char* getListenAddress() const;
 
-	/**
-	 * @return listen port
-	 */
+	/** @return listen port */
 	int getListenPort() const;
 
 	/** registers a RDP peer
@@ -165,6 +161,7 @@ public:
 	void repaint(const QRegion &region);
 
 	void registerBackingStore(QWindow *w, QFreeRdpBackingStore *back);
+	void dropBackingStore(QFreeRdpBackingStore *back);
 
 	/** @return the event dispatcher */
 	QAbstractEventDispatcher *getDispatcher() { return mEventDispatcher; }
@@ -191,10 +188,13 @@ protected:
 
     QFreeRdpPlatformConfig *mConfig;
     QFreeRdpScreen *mScreen;
+    QFreeRdpCursor *mCursor;
     QFreeRdpWindowManager *mWindowManager;
 	QFreeRdpListener *mListener;
 	bool mResourcesLoaded;
 	QMap<IconResourceType, IconResource*> mResources;
+	typedef QMap<QWindow *, QFreeRdpBackingStore *> BackingStoreMap;
+	BackingStoreMap mbackingStores;
 	QList<QFreeRdpPeer *> mPeers;
 	QString mPlatformName;
 };

--- a/src/plugins/platforms/freerdp/qfreerdpscreen.cpp
+++ b/src/plugins/platforms/freerdp/qfreerdpscreen.cpp
@@ -22,19 +22,18 @@
 
 #include "qfreerdpscreen.h"
 #include "qfreerdpplatform.h"
-#include "xcursors/qfreerdpxcursor.h"
 #include "qfreerdpwindowmanager.h"
 
 #include <QtCore/QtDebug>
 #include <QDebug>
 
 #include <qpa/qwindowsysteminterface.h>
+#include "xcursors/qfreerdpxcursor.h"
 
 QT_BEGIN_NAMESPACE
 
 QFreeRdpScreen::QFreeRdpScreen(QFreeRdpPlatform *platform, int width, int height)
 : mPlatform(platform)
-, mCursor(new QFreeRdpCursor(platform))
 {
 	qDebug("QFreeRdpScreen::%s(%d x %d)", __func__, width, height);
     mGeometry = QRect(0, 0, width, height);
@@ -45,7 +44,6 @@ QFreeRdpScreen::QFreeRdpScreen(QFreeRdpPlatform *platform, int width, int height
 QFreeRdpScreen::~QFreeRdpScreen() {
 	qDebug() << "QFreeRdpScreen::" << __func__ << "()";
 	delete mScreenBits;
-	delete mCursor;
 }
 
 QRect QFreeRdpScreen::geometry() const {
@@ -66,7 +64,7 @@ qreal QFreeRdpScreen::refreshRate() const {
 }
 
 QPlatformCursor *QFreeRdpScreen::cursor() const {
-	return mCursor;
+	return mPlatform->mCursor;
 }
 
 void QFreeRdpScreen::setGeometry(const QRect &geometry) {

--- a/src/plugins/platforms/freerdp/qfreerdpscreen.h
+++ b/src/plugins/platforms/freerdp/qfreerdpscreen.h
@@ -39,7 +39,7 @@ class QFreeRdpScreen : public QObject, public QPlatformScreen
     Q_OBJECT
 public:
     QFreeRdpScreen(QFreeRdpPlatform *platform, int width, int height);
-    ~QFreeRdpScreen();
+    virtual ~QFreeRdpScreen();
 
     QRect geometry() const override;
     int depth() const override;
@@ -55,7 +55,6 @@ protected:
     QRect mGeometry;
     QFreeRdpPlatform *mPlatform;
     QImage *mScreenBits;
-    QFreeRdpCursor *mCursor;
 };
 
 QT_END_NAMESPACE

--- a/src/plugins/platforms/freerdp/qfreerdpwindow.h
+++ b/src/plugins/platforms/freerdp/qfreerdpwindow.h
@@ -43,7 +43,7 @@ class QFreeRdpWindow : public QPlatformWindow
 
 public:
     QFreeRdpWindow(QWindow *window, QFreeRdpPlatform *platform);
-    ~QFreeRdpWindow();
+    virtual ~QFreeRdpWindow();
 
     void setBackingStore(QFreeRdpBackingStore *b);
 
@@ -75,7 +75,6 @@ public:
 protected:
     QFreeRdpPlatform *mPlatform;
     QFreeRdpBackingStore *mBackingStore;
-    QPlatformScreen *mScreen;
     WId mWinId;
     bool mVisible;
     bool mSentInitialResize;

--- a/src/plugins/platforms/freerdp/qfreerdpwindowmanager.cpp
+++ b/src/plugins/platforms/freerdp/qfreerdpwindowmanager.cpp
@@ -47,6 +47,9 @@ QFreeRdpWindowManager::QFreeRdpWindowManager(QFreeRdpPlatform *platform, int fps
 	connect(&mFrameTimer, SIGNAL(timeout()), this, SLOT(onGenerateFrame()));
 }
 
+QFreeRdpWindowManager::~QFreeRdpWindowManager() {
+}
+
 void QFreeRdpWindowManager::initialize() {
 	mFrameTimer.start((int)(1000 / mFps));
 }
@@ -161,7 +164,7 @@ void QFreeRdpWindowManager::repaint(const QRegion &region) {
 	//qDebug() << "dirtyRegion=" << dirtyRegion;
 
 	foreach(QFreeRdpWindow *window, mWindows) {
-		if(!window->isVisible())
+		if(!window->isVisible() || !window->windowContent())
 			continue;
 
 		QRect windowRect = window->geometry();

--- a/src/plugins/platforms/freerdp/qfreerdpwindowmanager.h
+++ b/src/plugins/platforms/freerdp/qfreerdpwindowmanager.h
@@ -42,6 +42,8 @@ class QFreeRdpWindowManager : public QObject {
 public:
 	QFreeRdpWindowManager(QFreeRdpPlatform *platform, int fps);
 
+	virtual ~QFreeRdpWindowManager();
+
 	void initialize();
 
 	void addWindow(QFreeRdpWindow *window);


### PR DESCRIPTION
Do an incremental refactoring to prepare the project for GL introduction, multiple monitors and dynamic resize.

Fix he handling of backingStore objects: they are associated with QWindow so when a new platform window is created scan for a previous association. That fixes some bugs with menus when sometime when the menu is shown, hidden then shown again the menu is not visible because of a backing store re-use.